### PR TITLE
feat(timer): add toggle to show timer alongside main clock

### DIFF
--- a/app/src/components/clock/Timer.svelte
+++ b/app/src/components/clock/Timer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    export let isShowedAlongsideClock: boolean = false;
     import { windowReady } from "html-ready";
 
     import styles from "./clockStyles/styles";
@@ -9,7 +10,7 @@
     } from "../../stores/storedSettings";
     import { clockIsVisible, styleChangeLock } from "../../stores/globalState";
     import { screenSaver } from "../../stores/globalState";
-    import { clockStyleClass } from "../../stores/storedSettings";
+    import { clockStyleClass, accentColor } from "../../stores/storedSettings";
     import IncomingEventsMessages from "./IncomingEventsMessages.svelte";
     import Divisor from "./Divisor.svelte";
     import Seconds from "./Seconds.svelte";
@@ -47,24 +48,42 @@
     }
 </script>
 
-<div
-    class="w-full justify-center flex flex-row items-center flex-nowrap {$clockStyleClass} font-semibold text-primary text-giant-0.5 lg:text-giant-1 transition-opacity
+{#if !isShowedAlongsideClock}
+    <div
+        class="w-full justify-center flex flex-row items-center flex-nowrap {$clockStyleClass} font-semibold text-primary text-giant-0.5 lg:text-giant-1 transition-opacity
         whitespace-nowrap w-auto h-full z-10 absolute top-0 left-0 select-none {$screenSaver &&
-    !$presentation
-        ? 'opacity-75'
-        : ''}"
->
-    <div class="relative">
-        <div class="absolute left-1/2 transform -translate-x-2/4">
-            <IncomingEventsMessages />
-        </div>
-        <div>
-            {#if hours !== "00"}
-                <ClockItem value={hours} /><Divisor />
-            {/if}<ClockItem value={minutes} /><Divisor /><ClockItem
-                color
-                value={seconds}
-            />
+        !$presentation
+            ? 'opacity-75'
+            : ''}"
+    >
+        <div class="relative">
+            <div class="absolute left-1/2 transform -translate-x-2/4">
+                <IncomingEventsMessages />
+            </div>
+            <div>
+                {#if hours !== "00"}
+                    <ClockItem value={hours} /><Divisor />
+                {/if}<ClockItem value={minutes} /><Divisor /><ClockItem
+                    color
+                    value={seconds}
+                />
+            </div>
         </div>
     </div>
-</div>
+{:else}
+    <div
+        class="relative opacity-60 text-primary text-lg lg:text-6xl
+           font-medium transition-opacity duration-300 select-none pointer-events-none m-5"
+    >
+        <p class="text-lg text-center">
+            <span style={`color: ${$accentColor};`}>Re</span>maining:
+        </p>
+        <div class="flex flex-row items-center space-x-1">
+            {#if hours !== "00"}
+                <ClockItem value={hours} /><span>:</span>
+            {/if}
+            <ClockItem value={minutes} /><span>:</span>
+            <ClockItem color value={seconds} />
+        </div>
+    </div>
+{/if}

--- a/app/src/components/sections/Home.svelte
+++ b/app/src/components/sections/Home.svelte
@@ -13,7 +13,11 @@
     import FloatingBlobs from "./FloatingBlobs/FloatingBlobs.svelte";
     import IncomingEventsBox from "../clock/IncomingEventsBox.svelte";
     import Bubble from "../elements/Bubble.svelte";
-    import { backgroundImage, timerTime } from "../../stores/storedSettings";
+    import {
+        backgroundImage,
+        timerTime,
+        showClockDuringTimer,
+    } from "../../stores/storedSettings";
     import SmoothImage from "../elements/SmoothImage.svelte";
     import Timer from "../clock/Timer.svelte";
 
@@ -69,9 +73,15 @@
     <FloatingBlobs />
 </div>
 
-<div class="h-screen relative" class:home-bg-image={$backgroundImage !== "none"}>
+<div
+    class="h-screen relative"
+    class:home-bg-image={$backgroundImage !== "none"}
+>
     {#if $backgroundImage !== "none"}
-        <SmoothImage classes="clock-bg-image absolute top-0 w-full h-full" src={$backgroundImage} />
+        <SmoothImage
+            classes="clock-bg-image absolute top-0 w-full h-full"
+            src={$backgroundImage}
+        />
         <!-- <HomeBackgroud cssClasses="absolute top-0 w-full h-full"></HomeBackgroud> -->
     {/if}
 
@@ -88,7 +98,7 @@
             if (!$screenSaver) disableScreenSaver;
         }}
     >
-        {#if $timerTime}
+        {#if $timerTime && !$showClockDuringTimer}
             <Timer />
         {:else}
             <Clock />
@@ -113,6 +123,12 @@
     <div class="absolute top-0 left-0" style="z-index: 2;">
         <Pinned />
     </div>
+
+    {#if $timerTime && $showClockDuringTimer}
+        <div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 z-20">
+            <Timer isShowedAlongsideClock={true} />
+        </div>
+    {/if}
 </div>
 
 <style global>

--- a/app/src/components/sections/settingsPage/Timer.svelte
+++ b/app/src/components/sections/settingsPage/Timer.svelte
@@ -4,6 +4,7 @@
     import TitleIcon from "../../elements/settings/TitleIcon.svelte";
     import PrimaryBox from "../../elements/settings/PrimaryBox.svelte";
     import Action from "../../elements/settings/Buttons/Action.svelte";
+    import Booleans from "../../elements/settings/Buttons/Booleans.svelte";
     import { onMount, tick } from "svelte";
     import moment, { Moment } from "moment";
     import momentDurationFormatSetup from "moment-duration-format";
@@ -15,6 +16,8 @@
     import { alarmTime, clockFormat, clockStyleClass, timerTime } from "../../../stores/storedSettings";
     import { canBeSummoned, shortcuts } from "../../../stores/rooster";
     import { ring, clearAlarmMemory, clearTimerMemory } from "../../../handlers/alarm";
+    import { showClockDuringTimer } from "../../../stores/storedSettings";
+    import NestedBox from "../../elements/settings/NestedBox.svelte";
 
     momentDurationFormatSetup(moment);
 
@@ -207,7 +210,7 @@
     <PrimaryBox
         label={{ text: primaryBoxTitle }}
         description={{
-            text: "Set a timer that will show on the main clock",
+            text: "Set a timer that will show on the main clock, unless the setting below is enabled",
             iconClass: "lnr lnr-question-circle",
         }}
         available={true}
@@ -223,6 +226,9 @@
                 : "text-secondary bg-highlighted border-primary"}
         ></Action>
     </PrimaryBox>
+    <NestedBox bordered label="Keep clock visible during timer">
+        <Booleans state={$showClockDuringTimer} label={"don't change main clock"} on:change={(e) => showClockDuringTimer.set(e.detail)} />
+    </NestedBox>
 </SettingsBox>
 
 <style>

--- a/app/src/stores/storedSettings.ts
+++ b/app/src/stores/storedSettings.ts
@@ -93,3 +93,5 @@ export const remindersRepeatedDefault = userSetting('remindersRepeatedDefault', 
 export const accentColor = userSetting('hoursColor', undefined, 'string');
 // clock class
 export const clockStyleClass = userSetting('clockStyleClass', 'font-monofur', 'string');
+// Timer
+export const showClockDuringTimer = userSetting('showClockDuringTimer', false, 'boolean');


### PR DESCRIPTION
This introduces a new toggle setting that allows the timer to be displayed alongside the main clock instead of replacing it. By default, the timer will still replace the clock, but enabling the setting keeps both visible.

# Screenshots
<img width="1908" height="883" alt="image" src="https://github.com/user-attachments/assets/d8e186b1-54dd-4280-840f-37d43d7bf1fc" />
<img width="781" height="322" alt="image" src="https://github.com/user-attachments/assets/f7948722-95fb-4f5b-9377-d432db8f49fb" />
